### PR TITLE
Fixes fs-cocoascript `readFile` to return a JavaScript string instead of an NSString.

### DIFF
--- a/src/fs-cocoascript.js
+++ b/src/fs-cocoascript.js
@@ -1,14 +1,20 @@
-import {stringToNSString} from './utils';
+import {
+    nsStringToString,
+    stringToNSString
+} from './utils';
 
-export const readFile = (file) =>
-    NSString
+export const readFile = (file) => {
+    const contents = NSString
         .stringWithContentsOfFile_encoding_error(
             stringToNSString(file),
             NSUTF8StringEncoding,
             nil
         );
 
-export const rename = (oldPath, newPath) =>
+    return nsStringToString(contents);
+};
+
+export const rename = (oldPath, newPath) => {
     NSFileManager
         .defaultManager()
         .moveItemAtPath_toPath_error(
@@ -16,8 +22,9 @@ export const rename = (oldPath, newPath) =>
             stringToNSString(newPath),
             nil
         );
+};
 
-export const writeFile = (file, data) =>
+export const writeFile = (file, data) => {
     NSString
         .stringWithString(data)
         .writeToFile_atomically_encoding_error(
@@ -26,3 +33,4 @@ export const writeFile = (file, data) =>
             NSUTF8StringEncoding,
             nil
         );
+};

--- a/src/fs-cocoascript.spec.js
+++ b/src/fs-cocoascript.spec.js
@@ -10,7 +10,9 @@ describe('fs-cocoascript', () => {
     test('should read file', () => {
         const expectedFile = chance.string();
         const expectedFileNSString = chance.string();
-        const stringWithContentsOfFileMock = jest.fn();
+        const expectedNSStringContents = chance.string();
+        const expectedContents = chance.string();
+        const stringWithContentsOfFileMock = jest.fn(() => expectedNSStringContents);
 
         global.nil = chance.string();
         global.NSString = {
@@ -18,11 +20,15 @@ describe('fs-cocoascript', () => {
         };
         global.NSUTF8StringEncoding = chance.string();
 
+        utils.nsStringToString = jest.fn((string) =>
+            string === expectedNSStringContents ? expectedContents : undefined
+        );
+
         utils.stringToNSString = jest.fn((file) =>
             file === expectedFile ? expectedFileNSString : undefined
         );
 
-        readFile(expectedFile);
+        const actualContents = readFile(expectedFile);
 
         expect(stringWithContentsOfFileMock).toBeCalled();
         expect(stringWithContentsOfFileMock).toBeCalledWith(
@@ -30,6 +36,7 @@ describe('fs-cocoascript', () => {
             global.NSUTF8StringEncoding,
             global.nil
         );
+        expect(actualContents).toBe(expectedContents);
     });
 
     test('should rename', () => {


### PR DESCRIPTION
Without this, no other JavaScript libraries, such as [svgo](https://github.com/svg/svgo), can use the contents.